### PR TITLE
fix 'linked_dylibs' for fat files with single arch

### DIFF
--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -131,10 +131,8 @@ module MachO
 		# All shared libraries linked to the file's Mach-Os.
 		# @return [Array<String>] an array of all shared libraries
 		def linked_dylibs
-			dylibs = machos.map(&:linked_dylibs).flatten
-
 			# can machos inside fat binaries have different dylibs?
-			dylibs.uniq!
+			machos.flat_map(&:linked_dylibs).uniq
 		end
 
 		# Changes all dependent shared library install names from `old_name` to `new_name`.


### PR DESCRIPTION
If there are no duplicates, `uniq!` returns nil instead of the array it operated on. Also use `flat_map` instead of `map` followed by `flatten` for performance reasons.

Possible alternatives:

- Reduce method to a single line: `machos.flat_map(&:linked_dylibs).uniq`.
- Retain the `dylibs.uniq!`, but add a line with just `dylibs` to return (the possibly unmodified) array.

One way to see a real-world failure due to this is to use `brew linkage gcc` (from [`homebrew/dev-tools`](https://github.com/Homebrew/homebrew-dev-tools)) on a `gcc` built with the `--without-multilib` option. The `lib/gcc/5/libgcc_s.1.dylib` will be a fat file with a single architecture and thus no duplicate dylib dependencies. (Originally discovered by testing against your PR Homebrew/homebrew#45001 with `HOMEBREW_RUBY_MACHO=1` set.)

(Not sure what your goals for testing are, so here's just the fix without any tests for now.)