### PR TITLE
consider all relevant commands in 'linked_dylibs'

### DIFF
--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -55,6 +55,16 @@ module MachO
 		0x2e => :LC_LINKER_OPTIMIZATION_HINT
 	}
 
+	# load commands responsible for loading dylibs
+	# @api private
+	DYLIB_LOAD_COMMANDS = [
+		:LC_LOAD_DYLIB,
+		:LC_LOAD_WEAK_DYLIB,
+		:LC_REEXPORT_DYLIB,
+		:LC_LAZY_LOAD_DYLIB,
+		:LC_LOAD_UPWARD_DYLIB,
+	].freeze
+
 	# association of load command symbols to string representations of classes
 	# @api private
 	LC_STRUCTURES = {

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -89,11 +89,11 @@ module MachO
 		:LC_CODE_SIGNATURE => "LinkeditDataCommand",
 		:LC_SEGMENT_SPLIT_INFO => "LinkeditDataCommand",
 		:LC_REEXPORT_DYLIB => "DylibCommand",
-		:LC_LAZY_LOAD_DYLIB => "LoadCommand", # undoc, maybe DylibCommand?
+		:LC_LAZY_LOAD_DYLIB => "DylibCommand",
 		:LC_ENCRYPTION_INFO => "EncryptionInfoCommand",
 		:LC_DYLD_INFO => "DyldInfoCommand",
 		:LC_DYLD_INFO_ONLY => "DyldInfoCommand",
-		:LC_LOAD_UPWARD_DYLIB => "LoadCommand", # undoc, maybe DylibCommand?
+		:LC_LOAD_UPWARD_DYLIB => "DylibCommand",
 		:LC_VERSION_MIN_MACOSX => "VersionMinCommand",
 		:LC_VERSION_MIN_IPHONEOS => "VersionMinCommand",
 		:LC_FUNCTION_STARTS => "LinkeditDataCommand",


### PR DESCRIPTION
Linked dylibs are not limited to the `LC_LOAD_DYLIB` load command. For completeness and consistency with `otool -L`, consider all relevant load commands (all with a `DylibCommand` structure, except `LC_ID_DYLIB`).

Also adjust `change_install_name` to work the same on the modification side and for consistency with `install_name_tool`.

One way to see a real-world issue due to this is to use `brew linkage qt5` (from [`homebrew/dev-tools`](https://github.com/Homebrew/homebrew-dev-tools)) on a normal `qt5` build. The output will be different depending on whether or not `HOMEBREW_RUBY_MACHO` is set because Qt uses weak linkage. (Discovered while testing Homebrew/homebrew#45001.)

(Not sure what your goals for testing are, so here's just the fix without any tests for now.)